### PR TITLE
Fix Exception when $children is not an array

### DIFF
--- a/src/bundle/Controller/UITreeMenuController.php
+++ b/src/bundle/Controller/UITreeMenuController.php
@@ -146,7 +146,7 @@ class UITreeMenuController extends Controller
         try {
             $children = $this->findNodes($location, null, $offset);
         } catch (NotFoundException $e) {
-            $children = null;
+            $children = [];
         }
 
         $response->setData([
@@ -210,11 +210,7 @@ class UITreeMenuController extends Controller
 
             $nodes[] = $childNode;
         }
-
-        if (empty($nodes)) {
-            return null;
-        }
-
+        
         return $nodes;
     }
 


### PR DESCRIPTION
Warning: count(): Parameter must be an array or an object that implements Countable

```
Symfony\Component\Debug\Exception\ContextErrorException:
Warning: count(): Parameter must be an array or an object that implements Countable

  at vendor/edgar/ez-uitreemenu-bundle/src/bundle/Controller/UITreeMenuController.php:154
  at Edgar\EzUITreeMenuBundle\Controller\UITreeMenuController->childrenAction(object(Location), 25)
     (vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php:151)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php:68)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (web/app.php:55)

```